### PR TITLE
Add quarto file for conversion of DynLib to CompDb

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,41 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[DESCRIPTION]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[*.c]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[*.R]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[*.Rmd]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[*.qmd]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[Makefile]
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,17 @@
 .Rhistory
 .RData
 .Ruserdata
+docs
+local_data
+*.o
+*.so
+/.quarto/
+vignettes/.quarto/
+/_site/
+*.html
+*.rmarkdown
+*.js
+*.css
+*.log
+*.h5
+data/*

--- a/dynlib-to-rforms-ftms-pos.qmd
+++ b/dynlib-to-rforms-ftms-pos.qmd
@@ -1,0 +1,677 @@
+---
+title: "Adapting the DynLib database layout for Spectra"
+format:
+  html:
+    toc: true
+    self-contained: true
+author: "Ahlam Mentag, Johannes Rainer"
+---
+
+# Introduction
+
+The DynLib database defines its own database/table layout which prevents the
+direct use of the data with R packages from the *RforMassSpectrometry*
+initiative. In this document we investigate and the current DynLib database
+structure and evaluate whether we can convert and translate the data into the
+database layouts used by e.g. the *CompoundDb* or the *MsBackendSql*
+packages. These packages define simple and flexible database layouts for storage
+of mass spectrometry (MS) data. The data from these databases can be directly
+loaded and represented as `Spectra` objects in R, which simplifies the use of
+the data in data analysis workflows. Re-using a database layout compatible with
+one of the above mentioned packages would simplify any future analysis and usage
+of the data since all the infrastructure to handle the MS data is already
+provided by the packages from the RforMassSpectrometry initiative.
+
+# Inspect the DynLib database
+
+We first inspect the data for one of the databases, the *FTMS positive polarity*
+data.
+
+```{r}
+pth <- "data/database_FTMS_pos/CSV"
+dir(pth)
+```
+
+We will next read the various csv files and inspect the data which is stored in
+each of them. We first read the *compound* table and list the data type of the
+various columns:
+
+```{r}
+compound <- read.table(file.path(pth, "compound.csv"), sep = "\t",
+                       header = TRUE)
+vapply(compound, class, NA_character_)
+```
+
+Most of the columns are of type character. Note that `"NULL"` is used for
+missing data (instead of `NA`) - we might want to change that.
+
+```{r}
+nrow(compound)
+length(unique(compound$COMPID))
+```
+
+Each row is thus one compound, with it's unique identifier.
+
+```{r}
+length(unique(compound$EXPID))
+```
+
+The column `EXPID` contains experiment identifiers - and does not contain any
+missing data.
+
+We next import the experiment table:
+
+```{r}
+experiment <- read.table(file.path(pth, "experiment.csv"), sep = "\t",
+                         header = TRUE)
+head(experiment)
+```
+
+The data types for the experiment columns:
+
+```{r}
+vapply(experiment, class, NA_character_)
+```
+
+We also check that the values in `"EXPID"` matches the values in the *compound*
+table.
+
+```{r}
+all(experiment$EXPID %in% compound$EXPID)
+```
+
+That's great.
+
+We next load the *spectra* table. The number of columns and headers
+unfortunately does not match:
+
+```{r}
+readLines(file.path(pth, "spectra.csv"), n = 4)
+```
+
+There are 5 column headers, but only 4 columns with values. We assume that the
+last column (`"MS5IDLIST"`) is empty for all spectra and import the remaining 4 columns.
+
+```{r}
+spectra <- read.table(file.path(pth, "spectra.csv"), sep = "\t",
+                      header = FALSE, skip = 1)
+colnames(spectra) <- c("COMPID", "MS2IDLIST", "MS3IDLIST", "MS4IDLIST")
+head(spectra)
+```
+
+We check the number of missing (`"NULL"`) values per column.
+
+```{r}
+nrow(spectra)
+vapply(spectra, function(z) sum(z == "NULL"), NA_integer_)
+```
+
+We have values for the first two columns while there are no non-missing values
+for the MS4 spectra. We next check if all entries in `"COMPID"` are also in the
+*compound* table.
+
+```{r}
+all(spectra$COMPID %in% compound$COMPID)
+all(compound$COMPID %in% spectra$COMPID)
+```
+
+OK. Finally also checking if `"COMPID"` and `"MS2IDLIST"` contain the same
+information.
+
+```{r}
+all(spectra$COMPID == spectra$MS2IDLIST)
+```
+
+OK, they are the same.
+
+Next we check the MS2 table.
+
+```{r}
+ms2 <- read.table(file.path(pth, "MS2spectra.csv"), sep = "\t", header = TRUE)
+head(ms2)
+```
+
+We have references to the compound, the precursor m/z (`"PARENT_ION"`) the m/z
+and intensity values (`"MS2PEAKLIST"` and `"MS2INTENSITYLIST"`) and also
+references to the associated MS3 spectra (`"MS3IDLIST"`). We check again if the
+identifiers are consistent with the other tables.
+
+```{r}
+all(ms2$COMPID %in% compound$COMPID)
+all(compound$COMPID %in% ms2$COMPID)
+all(spectra$COMPID %in% ms2$COMPID)
+all(ms2$COMPID %in% spectra$COMPID)
+```
+
+OK, the `"COMPID"` is consistent between the *compound*, *spectra* and *ms2*
+tables. Next we check whether the information in the *spectra* and *ms2* tables
+is redundant.
+
+```{r}
+all(spectra$COMPID == ms2$COMPID)
+all(spectra$MS3IDLIST == ms2$MS3IDLIST)
+```
+
+The content is indeed redundant. We next process the table to expand the
+`"MS3IDLIST"` and m/z and intensity columns.
+
+```{r}
+#' Helper function to replace `"NULL"` with `NA`.
+#'
+#' @param x `data.frame` or `matrix`.
+#'
+#' @return `x` with `"NULL"` replaced by `NA`.
+fix_na <- function(x) {
+    for (i in seq_len(ncol(x))) {
+        x[x[, i] == "NULL", i] <- NA
+    }
+    x
+}
+ms2 <- fix_na(ms2)
+
+#' expand the MS3IDLIST
+ms2$ms3id <- lapply(strsplit(ms2$MS3IDLIST, split = ","), as.integer)
+
+#' expand the m/z values
+ms2$mz <- lapply(strsplit(ms2$MS2PEAKLIST, split = ","), as.numeric)
+ms2$intensity <- lapply(strsplit(ms2$MS2INTENSITYLIST, split = ","),
+                        as.numeric)
+```
+
+Next we process the MS3 table.
+
+```{r}
+ms3 <- read.table(file.path(pth, "MS3spectra.csv"), sep = "\t", header = TRUE)
+head(ms3)
+
+```
+
+The format seems thus to be similar to the MS2 table. We next check again
+overlap of IDs with the other tables.
+
+```{r}
+all(ms3$COMPID %in% compound$COMPID)
+all(compound$COMPID %in% ms3$COMPID)
+```
+
+As expected, we don't have an entry for every compound in the *compound*
+table. We don't have the reference to the originating MS2 spectrum - but we
+should be able to link the MS3 from the MS2 table using the `"MS3IDLIST"`
+column.
+
+```{r}
+all_ms3_id <- unique(unlist(ms2$ms3id))
+all_ms3_id <- all_ms3_id[!is.na(all_ms3_id)]
+all(all_ms3_id %in% ms3$MS3ID)
+all(ms3$MS3ID %in% all_ms3_id)
+```
+
+At last replace the `"NULL"` values and split/extract the m/z and intensity
+values.
+
+```{r}
+ms3 <- fix_na(ms3)
+
+#' expand the MS4IDLIST
+ms3$ms4id <- lapply(strsplit(ms3$MS4IDLIST, split = ","), as.integer)
+
+#' expand the m/z values
+ms3$mz <- lapply(strsplit(ms3$MS3PEAKLIST, split = ","), as.numeric)
+ms3$intensity <- lapply(strsplit(ms3$MS3INTENSITYLIST, split = ","),
+                        as.numeric)
+```
+
+Importantly, we need to check if the identifiers within the different tables (in
+particular the MS2 and MS3 tables) are **unique** as we want to store these
+spectra into the same database table!
+
+```{r}
+cmn <- intersect(ms2$MS2ID, ms3$MS3ID)
+length(cmn)
+```
+
+So, indeed, the two tables share identifiers. Thus we **must** define a new
+ID/index for the MS2 and MS3 spectra.
+
+There are no MS4 and MS5 spectra, thus no need to check these files.
+
+
+# Comments and notes
+
+- `"NULL"` is used for missing data - we should replace that with `NA` to ensure
+  the respective columns can be converted properly to the right data type.
+- Each compound is associated with one (and only one) MS2 spectrum. The ID of
+  the compound and of the MS2 spectrum are always the same.
+- Each MS2 spectrum can have no, 1 or multiple MS3 spectra.
+- The *spectra* and *MS2spectra* tables contain redundant information. We would
+  not necessarily need the *spectra* table.
+- Identifiers are consistent between tables, i.e. there are no orphan IDs in any
+  table.
+- The `"MS2PEAKLIST"` in the MS2 csv file contains the m/z values of the
+  fragment peaks. It's integer values for the FTMS because the data was
+  generated in the ion trap at unit resolution.
+
+
+# The `CompDb` database layout
+
+The *MassBank* public MS reference library is stored in the `CompDb`
+layout. Below we load one of these databases from Bioconductor's *AnnotationHub*
+to investigate its structure.
+
+```{r}
+library(CompoundDb)
+library(AnnotationHub)
+ah <- AnnotationHub()
+mb <- ah[["AH119519"]]
+```
+
+We below access the associated SQLite database and list and investigate its
+tables.
+
+```{r}
+library(RSQLite)
+con <- dbconn(mb)
+
+dbListTables(con)
+```
+
+The main database tables are *ms_compound* (with the compound annotations),
+*msms_spectrum* (with MS spectrum metadata) and *msms_spectrum_peak* (with the
+actual mass peak values). Below we first inspect the *ms_compound* table:
+
+```{r}
+dbGetQuery(con, "select * from ms_compound limit 10;")
+```
+
+It contains thus compound annotations and a unique `"compound_id"` (note that
+compounds are redundant in the table, i.e. the same compound can be present more
+than one time - but each has its own `"compound_id"`). Next we evaluate the
+*msms_spectrum* table.
+
+```{r}
+dbGetQuery(con, "select * from msms_spectrum limit 10;")
+```
+
+This table has thus annotations for each spectrum, which includes also
+instrument information or the publication and authors that provide this
+spectrum. The column `"compound_id"` links this table to the *ms_compound*
+table. Each row in this table is associated with one compound. This associations
+is 1:n, i.e. one compound can be associated with multiple MS2 spectra, but each
+MS2 spectrum is only associated with one compound. Also, we have, in addition to
+MS2 spectra also MS3 and MS4 spectra available:
+
+```{r}
+dbGetQuery(con, "select distinct ms_level from msms_spectrum;")
+```
+
+Finally, we inspect the content of the *msms_spectrum_peaks* table.
+
+```{r}
+dbGetQuery(con, "select * from msms_spectrum_peak limit 10;")
+```
+
+Each row represents one mass peak - column `"spectrum_id"` refers to the
+originating MS spectrum.
+
+Generally, we don't need to access the data in the database using the SQL
+commands above. We can also use the functions from the *CompoundDb* package for
+a easier, R-centric, data access. To get all compounds we can for example simply
+use:
+
+```{r}
+cmps <- compounds(mb)
+head(cmps)
+```
+
+Or, get all data as a `Spectra` object:
+
+```{r}
+s <- Spectra(mb)
+spectraVariables(s)
+
+table(s$msLevel)
+```
+
+So, the `Spectra` would already *automatically* join the *ms_compound* and
+*msms_spectrum* tables.
+
+# Restructuring the database to the `CompDb` format
+
+Some notes and steps we will do:
+
+- Replace all `"NULL"` with `NA`.
+- All MS spectra should be stored into one database table
+- We use the `acquisitionNum` and `precScanNum` spectra variables to reference
+  between the MS 2 and MSn spectra. The (integer) value in `precScanNum` of a
+  MSn spectrum is always the spectrum ID of the parent MS spectrum and refers to
+  its `acquisitionNum`. With this we can use the `filterPrecursorScan()`
+  function from *Spectra* to get all related spectra from the database.
+- We need to define new spectrum identifiers as the identifiers for MS2 and MS3
+  spectra are not unique.
+
+## Compound and experiment data
+
+The compound information should ideally be stored in the *ms_compound* table. We
+can either split the experiment information into a separate table, or combine
+that into the *ms_compound*. This depends a bit on the amount of redundant data
+that would have to be stored into *ms_compound*, i.e. how many compounds to we
+generally have per experiment. We will store the compound  and the experiment
+tables to the database *as is* and only convert the upper case column names to
+lower case and replacing `"COMPID"` to `"compound_id"`. We need also to add
+additional required column names to the *ms_compound* database table, but can
+fill these with missing values.
+
+We first fix and create the *ms_compound* database table.
+
+```{r}
+ms_compound <- compound
+colnames(ms_compound) <- tolower(colnames(ms_compound))
+#' Rename "COMPID" -> compound_id
+colnames(ms_compound) <- sub("^compid", "compound_id", colnames(ms_compound))
+ms_compound$compound_id <- as.character(ms_compound$compound_id)
+#' Rename compname -> name
+colnames(ms_compound) <- sub("^compname", "name", colnames(ms_compound))
+#' Rename mass_theoretical -> exactmass
+colnames(ms_compound) <- sub("^mass_theoretical", "exactmass",
+                             colnames(ms_compound))
+#' Replace NULL with NA
+ms_compound <- fix_na(ms_compound)
+#' We add the remaining required columns
+ms_compound$inchi <- NA_character_
+ms_compound$inchikey <- NA_character_
+
+#' Ensure columns have the right data type.
+ms_compound$exactmass <- as.numeric(ms_compound$exactmass)
+ms_compound$ppm_deviation <- as.numeric(ms_compound$ppm_deviation)
+```
+
+Next we reformat the *experiment* database table.
+
+```{r}
+colnames(experiment) <- tolower(colnames(experiment))
+```
+
+
+## Collapsing the MS spectra data
+
+Ideally, all MS spectra should go into two tables, one with the metadata
+(*spectra variables*) and one with the mass peak data (*peaks data*). Also,
+spectra from all MS levels should be stored into the same table, keeping however
+the link/association to the respective precursor scan. This information (stored
+as `"MS2IDLIST"`, `"MS3IDLIST"` etc in DynLib) would need to be added to the
+`precScanNum` spectra variable, i.e. the ID (=index) of the spectrum should be
+stored in `acquisitionNum` and the parent spectrum in `precScanNum`.
+
+Below we create the respective tables starting with the MS2 spectra. Required
+database table columns in this table are:
+
+- `"spectrum_id"`: an arbitrary ID for the spectrum. Has to be an `integer`.
+- `"compound_id"`: the ID of the compound to which the spectrum can be
+  associated with. Needs to be `character`.
+- `"polarity"`: the polarity (as an `integer`, `0` for negative, `1` for
+  positive, `NA` for not set).
+- `"collision_energy"`: the collision energy.
+- `"predicted"`: whether the spectrum was predicted or measured.
+- `"splash"`: the SPLASH of the spectrum.
+- `"instrument_type"`: the instrument type.
+- `"instrument"`: the name of the instrument.
+- `"precursor_mz"`: the precursor m/z (as a `numeric`).
+
+We will need to add these if not already present. In addition, we set the
+`"dataOrigin"` spectra variable/column to the present project.
+
+```{r}
+#' Define the polarity for the present data: 0 for negative, 1 for positive.
+pol <- 1L
+proj <- "FTMS_pos"
+
+#' Define the spectrum_id for this MS level:
+sid <- seq_len(nrow(ms2))
+
+#' Create/extract the spectra metadata; we might need to add information like
+#' collision energy etc later, maybe.
+ms_2 <- data.frame(spectrum_id = sid,
+                   ms_level = rep(2L, nrow(ms2)),
+                   polarity = rep(pol, nrow(ms2)),
+                   compound_id = as.character(ms2$COMPID),
+                   precursor_mz = ms2$PARENT_ION,
+                   instrument = rep(experiment$machine[1L], nrow(ms2)),
+                   instrument_type = rep(experiment$mstype[1L], nrow(ms2)),
+                   acquisitionNum = sid,
+                   precScanNum = rep(NA_integer_, nrow(ms2)),
+                   collision_energy = rep(NA_character_, nrow(ms2)),
+                   predicted = rep(FALSE, nrow(ms2)),
+                   splash = rep(NA_character_, nrow(ms2)),
+                   dataOrigin = rep(proj, nrow(ms2)),
+                   original_id = ms2$MS2ID)
+
+#' Expand the peaks data to one fragment peak per row
+msms_spectrum_peak <- data.frame(
+    spectrum_id = rep(sid, lengths(ms2$intensity)),
+    mz = as.numeric(unlist(ms2$mz, use.names = FALSE)),
+    intensity = as.numeric(unlist(ms2$intensity, use.names = FALSE)))
+```
+
+**Note** the m/z values are not sorted increasingly in the MS2 spectra - which
+we should ensure they are before adding the `"peak_id"` column!
+
+Next we add the MS3 data. What is a bit odd is that we don't have the MS2ID
+column in that table. So, we will use the `"MS3IDLIST"` in the MS2 table to
+assign the respective IDs/indices to the table. Also, we need to link the
+`"precScanNum"` column to the new `"spectrum_id"` we defined for the MS2
+spectra.
+
+```{r}
+#' Define spectrum_id for this MS level
+sid <- seq(sid[length(sid)] + 1L, length.out = nrow(ms3))
+#' Create the content for the MS level 3
+ms_3 <- data.frame(spectrum_id = sid,
+                   ms_level = rep(3L, nrow(ms3)),
+                   polarity = rep(pol, nrow(ms3)),
+                   compound_id = as.character(ms3$COMPID),
+                   precursor_mz = ms3$PARENT_ION,
+                   instrument = rep(experiment$machine[1L], nrow(ms3)),
+                   instrument_type = rep(experiment$mstype[1L], nrow(ms3)),
+                   acquisitionNum = sid,
+                   precScanNum = rep(NA_integer_, nrow(ms3)),
+                   collision_energy = rep(NA_character_, nrow(ms3)),
+                   predicted = rep(FALSE, nrow(ms3)),
+                   splash = rep(NA_character_, nrow(ms3)),
+                   dataOrigin = rep(proj, nrow(ms3)),
+                   original_id = ms3$MS3ID)
+
+#' Need to assign the spectrum_id of the MS2 spectra into the precScanNum
+#' of the associated MS3 spectra. The association is through MS3IDLIST
+#' get the mapping between ms2 and ms3 IDs.
+map_2_3 <- data.frame(ms2 = rep(ms2$MS2ID, lengths(ms2$ms3id)),
+                      ms3 = unlist(ms2$ms3id))
+#' Get rid of MS2 spectra without MS3 spectra.
+map_2_3 <- map_2_3[!is.na(map_2_3$ms3), ]
+
+#' Need to convert this mapping to the new spectrum_id
+id_2_3 <- cbind(ms2 = ms_2$spectrum_id[match(map_2_3$ms2, ms2$MS2ID)],
+                ms3 = ms_3$spectrum_id[match(map_2_3$ms3, ms3$MS3ID)])
+
+#' Assign the MS2 ID to the "precScanNum" column of the respective MS3 scan
+ms_3$precScanNum[match(id_2_3[, 2L], ms_3$spectrum_id)] <- id_2_3[, 1L]
+
+#' Combine with msms_spectrum
+msms_spectrum <- rbind(ms_2, ms_3)
+
+#' Process peaks data
+tmp <- data.frame(
+    spectrum_id = rep(sid, lengths(ms3$intensity)),
+    mz = as.numeric(unlist(ms3$mz, use.names = FALSE)),
+    intensity = as.numeric(unlist(ms3$intensity, use.names = FALSE)))
+#' Append to the *final* peaks table
+msms_spectrum_peak <- rbind(msms_spectrum_peak, tmp)
+```
+
+At last we have to ensure that mass (fragment) peaks are increasingly
+ordered. Also, we add a *peak_id* column to the table.
+
+```{r}
+#' Order the peak by m/z per spectrum
+msms_spectrum_peak <- msms_spectrum_peak[
+    order(msms_spectrum_peak$spectrum_id, msms_spectrum_peak$mz), ]
+
+#' at last adding the peak_id as a running integer
+msms_spectrum_peak$peak_id <- seq_len(nrow(msms_spectrum_peak))
+```
+
+Validating that the relationship between the MS2 and MS3 scans is still correct:
+
+```{r}
+ms2_id <- ms2$MS2ID[2]
+ms3_ids <- ms2$ms3id[[2]]
+
+#' Get the MS2 spectrum
+a <- msms_spectrum[msms_spectrum$original_id == ms2_id &
+                   msms_spectrum$ms_level == 2, ]
+#' Get all associated MS3 spectra
+b <- msms_spectrum[msms_spectrum$precScanNum == a$spectrum_id &
+                   msms_spectrum$ms_level == 3, ]
+all.equal(b$original_id, ms3_ids)
+
+## Repeat for another
+ms2_id <- ms2$MS2ID[4]
+ms3_ids <- ms2$ms3id[[4]]
+
+#' Get the MS2 spectrum
+a <- msms_spectrum[msms_spectrum$original_id == ms2_id &
+                   msms_spectrum$ms_level == 2, ]
+#' Get all associated MS3 spectra
+b <- msms_spectrum[msms_spectrum$precScanNum == a$spectrum_id &
+                   msms_spectrum$ms_level == 3, ]
+all.equal(b$original_id, ms3_ids)
+
+```
+
+
+## Export the data
+
+All tables are created and we can next export/write these to a SQLite database.
+
+```{r}
+dbf <- file.path("data", "DyLib_FTMS_pos.sqlite")
+if (file.exists(dbf)) file.remove(dbf)
+con <- dbConnect(SQLite(), dbf)
+```
+
+As a first table we store a *metadata* table to the database. This table should
+contain some general info on the version and content of the database.
+
+```{r}
+md <- make_metadata(source = "DynLib FTMS pos", url = NA_character_,
+                    source_version = "1.0.0", source_date = "2025-05-15")
+dbWriteTable(con, name = "metadata", md, row.names = FALSE)
+```
+
+Next we write the compound and experiment data. The `CompDb` database layout
+supports multiple names per compound. For this we need to add an additional
+(empty) database table *synonym*.
+
+```{r}
+#' Write empty synonym table
+snm <- data.frame(compound_id = integer(), synonym = character())
+dbWriteTable(con, name = "synonym", snm, row.names = FALSE)
+
+#' Write compound table
+dbWriteTable(con, name = "ms_compound", ms_compound, row.names = FALSE)
+
+#' Write experiment table
+dbWriteTable(con, name = "experiment", experiment, row.names = FALSE)
+```
+
+Next we write the MS data to the database.
+
+```{r}
+dbWriteTable(con, name = "msms_spectrum_peak", msms_spectrum_peak,
+             row.names = FALSE)
+dbWriteTable(con, name = "msms_spectrum", msms_spectrum, row.names = FALSE)
+```
+
+At last we create the indices.
+
+```{r}
+#' experiment
+tmp <- dbExecute(con, "create index experiment_expid_idx on experiment (expid)")
+
+#' ms_compound
+tmp <- dbExecute(
+    con, "create index compound_id_idx on ms_compound (compound_id)")
+tmp <- dbExecute(
+    con, "create index compound_name_idx on ms_compound (name)")
+tmp <- dbExecute(
+    con, "create index compound_expid_idx on ms_compound (expid)")
+
+#' msms_spectrum
+tmp <- dbExecute(
+    con, "create index spectrum_id_idx on msms_spectrum (spectrum_id)")
+tmp <- dbExecute(
+    con, "create index spectrum_cmp_id_idx on msms_spectrum (compound_id)")
+tmp <- dbExecute(
+    con, "create index msms_psn_idx on msms_spectrum (precScanNum)")
+tmp <- dbExecute(
+    con, "create index msms_an_idx on msms_spectrum (acquisitionNum)")
+
+
+#' msms_spectrum_peak
+tmp <- dbExecute(
+    con, "create index msms_id_idx on msms_spectrum_peak (spectrum_id)")
+
+dbDisconnect(con)
+```
+	
+## Testing the created database
+
+At last we evaluate whether we can use the created database using the
+*CompoundDb*/*Spectra* packages.
+
+```{r}
+library(Spectra)
+library(CompoundDb)
+
+dbf <- file.path("data", "DyLib_FTMS_pos.sqlite")
+
+#' Load the database as a `CompDb` object
+cdb <- CompDb(dbf)
+cdb
+```
+
+Get access to the compounds:
+
+```{r}
+compounds(cdb) |> head()
+```
+
+Get access to the MS spectra data.
+
+```{r}
+s <- Spectra(cdb)
+s
+```
+
+Check if we could get all fragment spectra for one compound.
+
+```{r}
+cmpid <- 16078
+
+a <- s[s$compound_id == cmpid]
+
+sid <- 4
+
+#' This is not yet working - I need to fix.
+#' s$dataOrigin <- "DynLib"
+#' filterPrecursorScan(s, 4)
+```
+
+
+Only, at present we don't have a simple function to extract the experiment data
+- we would need to extract that using SQL queries.
+
+# Session information
+
+```{r}
+sessionInfo()
+```


### PR DESCRIPTION
This quarto document converts the FTMS_pos DynLib database to a SQLite database in a format which is compatible with the *CompoundDb* package.