### PR TITLE
refactor: start splitting similarity function into two functions

### DIFF
--- a/Similarity/sim_functions.R
+++ b/Similarity/sim_functions.R
@@ -19,79 +19,163 @@ remove_duplicates <- function(mz, intensity) {
   return(list(mz = unique_mz, intensity = max_intensity))
 }
 
-symmetric_dotproduct_combined <- function(x, y, xPrecursorMz, yPrecursorMz, n = 3, m = 0.6, ...) {
-  
-  mz1 <- as.numeric(unlist(x[, 1L]))
-  intensity1 <- as.numeric(unlist(x[, 2L]))
-  mz2 <- as.numeric(unlist(y[, 1L]))
-  intensity2 <- as.numeric(unlist(y[, 2L]))
-  
-  if (length(mz1) == 0 || length(mz2) == 0) 
+#' @description
+#'
+#' Function to calculate the symmetric dot product between two spectra. The
+#' function also:
+#'
+#' - *cleans* the spectra keeping only a single fragment peak for groups of
+#'   peaks with a m/z smaller 0.5
+#'
+#' @param x `numeric` 2-column `matrix` with the m/z and intensity values
+#'
+#' @param y `numeric` 2-column `matrix` with the m/z and intensity values
+#'
+#' @param xPrecursorMz `numeric(1)` with the precursor m/z of the spectrum `x`
+#'
+#' @param yPrecursorMz `numeric(1)` with the precursor m/z of the spectrum `y`
+#'
+#' @param n
+#'
+#' @param m
+#'
+#' @author Ahlam Mentag
+symmetric_dotproduct_combined <- function(x, y, xPrecursorMz,
+                                          yPrecursorMz, n = 3, m = 0.6, ...) {
+  if (!nrow(x) || !nrow(y))
     return(list(common_peaks = 0, similarity_score = 0))
-  
-  cleaned1 <- remove_duplicates(mz1, intensity1)
-  cleaned2 <- remove_duplicates(mz2, intensity2)
-  
+
+  cleaned1 <- remove_duplicates(x[, 1L], x[, 2L])
+  cleaned2 <- remove_duplicates(z[, 1L], y[, 2L])
+
   mz1 <- cleaned1$mz
   intensity1 <- cleaned1$intensity
   mz2 <- cleaned2$mz
   intensity2 <- cleaned2$intensity
-  
+
   intensity1 <- (intensity1^n) * (mz1^m)
   intensity2 <- (intensity2^n) * (mz2^m)
-  
+
   Fd_denom1 <- sum(intensity1^2)
   Fd_denom2 <- sum(intensity2^2)
-  
+
   common_mz <- intersect(mz1, mz2)
   Fd_nom <- 0
   remaining_idx1 <- rep(TRUE, length(mz1))
   remaining_idx2 <- rep(TRUE, length(mz2))
-  
+
   if (length(common_mz) > 0) {
     idx1 <- match(common_mz, mz1)
     idx2 <- match(common_mz, mz2)
-    
+
     valid_indices <- !is.na(idx1) & !is.na(idx2)
     idx1 <- idx1[valid_indices]
     idx2 <- idx2[valid_indices]
-    
+
     if (length(idx1) > 0 && length(idx2) > 0) {
       Fd_nom <- sum(intensity1[idx1] * intensity2[idx2])
     }
-    
+
     remaining_idx1[idx1] <- FALSE
     remaining_idx2[idx2] <- FALSE
   }
-  
+
   # Calcul des neutral losses sur les pics restants
   nl1 <- neutral_loss(mz1[remaining_idx1], xPrecursorMz)
   nl2 <- neutral_loss(mz2[remaining_idx2], yPrecursorMz)
-  
+
   common_nl <- intersect(nl1, nl2)
-  
+
   if (length(common_nl) > 0) {
     for (nl in common_nl) {
       matches1 <- which(nl1 == nl)
       matches2 <- which(nl2 == nl)
-      
+
       if (length(matches1) > 0 && length(matches2) > 0) {
-        Fd_nom <- Fd_nom + sum(intensity1[remaining_idx1][matches1]) * 
+        Fd_nom <- Fd_nom + sum(intensity1[remaining_idx1][matches1]) *
           sum(intensity2[remaining_idx2][matches2])
       }
     }
   }
-  
+
   FD <- if (Fd_nom > 0) (Fd_nom^2) / (Fd_denom1 * Fd_denom2) else 0
-  
+
   total_common <- length(common_mz) + length(common_nl)
-  
+
   return(FD)
 }
 
 
+#' @description
+#'
+#' Matches/maps peaks between the two provided peak matrices.
+#'
+#' @return
+#'
+#' a `list` with `numeric` matrices containing only the matched peaks between
+#' the two input spectra.
+#'
+#' @author Ahlam Mentag
+dynlib_map <- function(x, y, xPrecursorMz, yPrecursorMz, ...) {
+    if (!nrow(x) || !nrow(y))
+        return(list(x = matrix(numeric(), ncol = 3, nrow = 0),
+                    y = matrix(numeric(), ncol = 3, nrow = 0)))
 
+    cleaned1 <- remove_duplicates(x[, 1L], x[, 2L])
+    cleaned2 <- remove_duplicates(z[, 1L], y[, 2L])
 
+    mz1 <- cleaned1$mz
+    mz2 <- cleaned2$mz
+    ## Continue from here - keep only the rows in `cleaned1` or `cleaned2` that
+    ## have matching m/z between the two.
+    common_mz <- intersect(mz1, mz2)
+    remaining_idx1 <- rep(TRUE, length(mz1))
+    remaining_idx2 <- rep(TRUE, length(mz2))
+
+  if (length(common_mz) > 0) {
+    idx1 <- match(common_mz, mz1)
+    idx2 <- match(common_mz, mz2)
+
+    valid_indices <- !is.na(idx1) & !is.na(idx2)
+    idx1 <- idx1[valid_indices]
+    idx2 <- idx2[valid_indices]
+
+    if (length(idx1) > 0 && length(idx2) > 0) {
+      Fd_nom <- sum(intensity1[idx1] * intensity2[idx2])
+    }
+
+    remaining_idx1[idx1] <- FALSE
+    remaining_idx2[idx2] <- FALSE
+  }
+
+  # Calcul des neutral losses sur les pics restants
+  nl1 <- neutral_loss(mz1[remaining_idx1], xPrecursorMz)
+  nl2 <- neutral_loss(mz2[remaining_idx2], yPrecursorMz)
+
+  common_nl <- intersect(nl1, nl2)
+
+  if (length(common_nl) > 0) {
+    for (nl in common_nl) {
+      matches1 <- which(nl1 == nl)
+      matches2 <- which(nl2 == nl)
+
+      if (length(matches1) > 0 && length(matches2) > 0) {
+        Fd_nom <- Fd_nom + sum(intensity1[remaining_idx1][matches1]) *
+          sum(intensity2[remaining_idx2][matches2])
+      }
+    }
+  }
+
+  FD <- if (Fd_nom > 0) (Fd_nom^2) / (Fd_denom1 * Fd_denom2) else 0
+
+  total_common <- length(common_mz) + length(common_nl)
+
+  return(FD)
+
+}
+
+dynlib_fun <- function() {
+}
 
 
 
@@ -102,48 +186,48 @@ count_common_peaks <- function(x, y, xPrecursorMz, yPrecursorMz, ...) {
   intensity1 <- intensity(x)[[1]]
   mz2 <- mz(y)[[1]]
   intensity2 <- intensity(y)[[1]]
-  
+
   # Check for empty spectra
   if (length(mz1) == 0 || length(mz2) == 0)
     return(0)
-  
+
   # Remove duplicates
   cleaned1 <- remove_duplicates(mz1, intensity1)
   cleaned2 <- remove_duplicates(mz2, intensity2)
-  
+
   mz1 <- cleaned1$mz
   intensity1 <- cleaned1$intensity
   mz2 <- cleaned2$mz
   intensity2 <- cleaned2$intensity
-  
+
   # Find common m/z values
   common_mz <- intersect(mz1, mz2)
   remaining_idx1 <- rep(TRUE, length(mz1))
   remaining_idx2 <- rep(TRUE, length(mz2))
-  
+
   if (length(common_mz) > 0) {
     idx1 <- match(common_mz, mz1)
     idx2 <- match(common_mz, mz2)
-    
+
     valid_indices <- !is.na(idx1) & !is.na(idx2)
     idx1 <- idx1[valid_indices]
     idx2 <- idx2[valid_indices]
-    
+
     remaining_idx1[idx1] <- FALSE
     remaining_idx2[idx2] <- FALSE
   }
-  
+
   common_peaks <- length(common_mz)
-  
+
   # Calculate neutral losses only on remaining peaks
   nl1 <- neutral_loss(mz1[remaining_idx1], xPrecursorMz)
   nl2 <- neutral_loss(mz2[remaining_idx2], yPrecursorMz)
-  
+
   common_nl <- intersect(nl1, nl2)
-  
+
   # Add common neutral losses to common peaks count
   common_peaks <- common_peaks + length(common_nl)
-  
+
   return(common_peaks)
 }
 
@@ -156,7 +240,7 @@ library(Spectra)
 
 compare_with_metaboannotation <- function(st_sps, filtered_dy_sps, threshold = 0.8, ppm = 5, tolerance = 0.005) {
   library(MetaboAnnotation)
-  
+
   param <- CompareSpectraParam(
     ppm = ppm,
     tolerance = tolerance,
@@ -164,15 +248,15 @@ compare_with_metaboannotation <- function(st_sps, filtered_dy_sps, threshold = 0
     FUN = symmetric_dotproduct_combined,
     threshold = threshold
   )
-  
+
   matches <- matchSpectra(
     query = st_sps,
     target = filtered_dy_sps,
     param = param
   )
-  
+
   df <- as.data.frame(matches)
   df <- df[df$score >= threshold, ]
-  
+
   return(df)
 }


### PR DESCRIPTION
I think it would be best to split the `symmetric_dotproduct_combined()` functions into two separate functions, one that maps/matches the peaks between the compared spectra and one that calculates the similarity. With that it should be possible to use the similarity calculation directly in `Spectra::compareSpectra()` and `MetaboAnnotation::matchSpectra()` functions - including the reporting of the number of matched peaks.

So, the first function `dynlib_map()` I started to sketch down would take the input peak matrices `x` and `y` as well as `xPrecursorMz` and `yPrecursorMz` as input parameters and would return a `list` of 2 peak matrices that contains **only** the matching peaks.

The result of the function should look like e.g.

```r
$x
      [,1] [,2]
[1,]  12.5  100
[2,] 100.0  200

$y
      [,1] [,2]
[1,]  12.5  150
[2,] 100.0  200
```

i.e. be a `list` with elements `x` and `y` and each of them being a `matrix` with the m/z in the first and intensity values in the second column.

That could then be passed to the second function that calculates the similarity score based on these. @Ahlammentag , check also the comments I mode in the code for more info.